### PR TITLE
fix deprecated method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "argcomplete",
         "appdirs<1.5",
-        "slacker<0.12.0",
+        "slacker<0.14.0",
         "websocket-client<0.55.0",
     ],
     extras_require={"development": ["black", "pylint"]},

--- a/slackcli/messaging.py
+++ b/slackcli/messaging.py
@@ -28,8 +28,8 @@ def iter_resources():
     # https://api.slack.com/methods/conversations.list
     # https://github.com/os/slacker/issues/116
     fetchers = [
-        ("channel", lambda: slack.client().channels.list().body["channels"]),
-        ("group", lambda: slack.client().groups.list().body["groups"]),
+        ("channel", lambda: slack.client().conversations.list().body["channels"]),
+        #("group", lambda: slack.client().groups.list().body["groups"]),
         ("user", lambda: slack.client().users.list().body["members"]),
     ]
     for resource_type, fetcher in fetchers:


### PR DESCRIPTION
Fixes the following error:

```
Traceback (most recent call last):
  File "/Users/vagelim/.pyenv/versions/3.7.0/bin/slack-cli", line 33, in <module>
    sys.exit(load_entry_point('slack-cli==2.2.9', 'console_scripts', 'slack-cli')())
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slackcli/cli.py", line 27, in main
    sys.exit(run())
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slackcli/cli.py", line 140, in run
    send_message(args.dst, message, pre=args.pre, username=args.user)
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slackcli/cli.py", line 187, in send_message
    destination_id = messaging.get_destination_id(destination)
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slackcli/messaging.py", line 13, in get_destination_id
    return get_resource(name)[1]["id"]
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slackcli/messaging.py", line 17, in get_resource
    for resource_type, resource in iter_resources():
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slackcli/messaging.py", line 36, in iter_resources
    for resource in fetcher():
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slackcli/messaging.py", line 31, in <lambda>
    ("channel", lambda: slack.client().channels.list().body["channels"]),
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slacker/__init__.py", line 428, in list
    'exclude_members': exclude_members})
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slacker/__init__.py", line 120, in get
    api, **kwargs
  File "/Users/vagelim/.pyenv/versions/3.7.0/lib/python3.7/site-packages/slacker/__init__.py", line 102, in _request
    raise Error(response.error)
slacker.Error: method_deprecated
```